### PR TITLE
reduce connection count on return by pool

### DIFF
--- a/src/main/java/kr/teamcocoa/mysql/mysql/pool/ConnectionPool.java
+++ b/src/main/java/kr/teamcocoa/mysql/mysql/pool/ConnectionPool.java
@@ -82,9 +82,12 @@ public class ConnectionPool {
             CompletableFuture<MySQL> completableFuture = waitingConnectionPool.poll();
             completableFuture.complete(mySQL);
         }
+        else if(this.currentSize > this.initialSize) {
+            mysql.disconnect();
+            this.currentSize--;
+        } 
         else {
             queue.add(mySQL);
         }
     }
-
 }


### PR DESCRIPTION
Over populated amount of connection object unnecessary will be destroyed when returned.

https://discord.com/channels/602617267146063883/603522027680301060/1164407087208595466